### PR TITLE
docker-slack-message: Set message as fallback text

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ func content(cfg config) slack.MsgOption {
 	}
 
 	attachment := slack.Attachment{
+		Fallback: cfg.Message,
 		Blocks: slack.Blocks{BlockSet: blocks},
 		Color:  cfg.Color,
 	}


### PR DESCRIPTION
Since we use attachments and not blocks with `text`, notifications are rendered with "[no preview available]". The same happens when sharing messages within Slack too. Fortunately, [attachments have a field called `fallback`][field] which is used for notifications. Let's set that.

![image](https://github.com/grafana/docker-slack-message/assets/321014/34276e97-f2ac-4413-a215-698c0bea975a)

[field]: https://api.slack.com/reference/messaging/attachments#legacy_fields