### PR TITLE
Use title as fallback if no message body provided

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,10 +84,15 @@ func content(cfg config) slack.MsgOption {
 		))
 	}
 
+	fallback := cfg.Message
+	if fallback == "" {
+		fallback = cfg.Title
+	}
+
 	attachment := slack.Attachment{
-		Fallback: cfg.Message,
-		Blocks: slack.Blocks{BlockSet: blocks},
-		Color:  cfg.Color,
+		Fallback: fallback,
+		Blocks:   slack.Blocks{BlockSet: blocks},
+		Color:    cfg.Color,
 	}
 
 	return slack.MsgOptionAttachments(attachment)


### PR DESCRIPTION
Builds on https://github.com/grafana/docker-slack-message/pull/29 to use the message title as the fallback text if no message body is provided.