### PR TITLE
ci: update to dockerhub login to use shared workflow instead 

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -13,12 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      uses: grafana/shared-workflows/actions/dockerhub-login@117d8511cbc5da0337972deeb400c4298b057af3 #v1.0.1
       if: github.event_name != 'pull_request'
     - uses: actions/checkout@v4
+      with: 
+        persist-credentials: false
     - run: make build
     - run: make push
       if: github.event_name != 'pull_request'


### PR DESCRIPTION
Noticed that the CI pipeline on main was failing due to lack of permissions--changing the pipeline to use the login to dockerhub shared workflow instead. 