### PR TITLE
ci: reconfigure the login to docker to use the shared-workflow action instead

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -23,4 +23,3 @@ jobs:
           persist-credentials: false
     - run: make build
     - run: make push
-      if: github.event_name != 'pull_request'

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,7 +17,7 @@ jobs:
       
     steps:
     - name: Login to Docker Hub
-      uses: grafana/shared-workflows/actions/dockerhub-login@117d8511cbc5da0337972deeb400c4298b057af3 #v1.0.1
+      uses: grafana/shared-workflows/actions/dockerhub-login@117d8511cbc5da0337972deeb400c4298b057af3 # dockerhub-login-v1.0.1
       if: github.event_name != 'pull_request'
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -13,12 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      uses: grafana/shared-workflows/actions/dockerhub-login@117d8511cbc5da0337972deeb400c4298b057af3 #v1.0.1
       if: github.event_name != 'pull_request'
     - uses: actions/checkout@v4
+      with: 
+        persist-credentials: false
     - run: make build
     - run: make push
       if: github.event_name != 'pull_request'

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -18,7 +18,6 @@ jobs:
     steps:
     - name: Login to Docker Hub
       uses: grafana/shared-workflows/actions/dockerhub-login@117d8511cbc5da0337972deeb400c4298b057af3 #v1.0.1
-      if: github.event_name != 'pull_request'
     - uses: actions/checkout@v4
       with:
           persist-credentials: false

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: 
       contents: read
+      id-token: write
       
     steps:
     - name: Login to Docker Hub

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -18,8 +18,10 @@ jobs:
     steps:
     - name: Login to Docker Hub
       uses: grafana/shared-workflows/actions/dockerhub-login@117d8511cbc5da0337972deeb400c4298b057af3 #v1.0.1
+      if: github.event_name != 'pull_request'
     - uses: actions/checkout@v4
       with:
           persist-credentials: false
     - run: make build
     - run: make push
+      if: github.event_name != 'pull_request'


### PR DESCRIPTION
Noticed that my previous PR made the piepline fail due to a login error and it was still using Github secrets, so reconfiguring the CI to use the shared workflow (that uses Vault) instead. 