### PR TITLE
chore(dockerfile): add jq to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN CGO_ENABLED=0 go build -o slack-message ./...
 FROM alpine:latest@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
 
 COPY --from=build /app/slack-message /app/slack-message
+RUN apk add --no-cache jq
 RUN mkdir /app/outputs
 
 ENTRYPOINT ["/app/slack-message"]


### PR DESCRIPTION
This PR adds jq to the Docker image to support JSON parsing of the GitHub-to-Slack mapping API responses being added to Argo Workflows. This will eliminate the need for [adding it at runtime](https://github.com/grafana/deployment_tools/pull/356844/files#diff-aac891893abcbcf681396c529907ffb07193f09fe9f1fd7e725dba60bc2864e0R12).