### PR TITLE
chore(dockerfile): reorder jq install in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN CGO_ENABLED=0 go build -o slack-message ./...
 
 FROM alpine:latest@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
 
-COPY --from=build /app/slack-message /app/slack-message
 RUN apk add --no-cache jq
+COPY --from=build /app/slack-message /app/slack-message
 RUN mkdir /app/outputs
 
 ENTRYPOINT ["/app/slack-message"]


### PR DESCRIPTION
This PR reorders the installation of jq in the Docker image to take advantage of Docker's caching behavior. Thanks @ricky-undeadcoders!