### PR TITLE
Enable Slack mentions for messages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Run tests
+        run: make test
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN CGO_ENABLED=0 go build -o slack-message ./...
 
 FROM alpine:latest@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
 
-RUN apk add --no-cache jq curl
 COPY --from=build /app/slack-message /app/slack-message
 RUN mkdir /app/outputs
 

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,7 @@ push: build
 	docker push $(COMMIT_IMAGE)
 	docker push $(DATE_IMAGE)
 
+.PHONY: test
+test:
+	go test ./...
+

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,16 @@
 module github.com/grafana/docker-slack-message
 
-go 1.22
+go 1.25
 
 require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/slack-go/slack v0.17.3
+	github.com/stretchr/testify v1.11.1
 )
 
-require github.com/gorilla/websocket v1.5.3 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/slack-go/slack v0.17.3 h1:zV5qO3Q+WJAQ/XwbGfNFrRMaJ5T/naqaonyPV/1TP4g=
 github.com/slack-go/slack v0.17.3/go.mod h1:X+UqOufi3LYQHDnMG1vxf0J8asC6+WllXrVrhl8/Prk=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ type config struct {
 
 const (
 	slackMentionTimeout   = 30 * time.Second
-	usernameBoundaryClass = `[^A-Za-z0-9-]`
+	usernameBoundaryClass = `[^A-Za-z0-9_-]`
 )
 
 type slackUserNotFoundError struct {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newTestClient(fn roundTripFunc) *http.Client {
+	return &http.Client{Transport: fn}
+}
+
+func TestContainsGitHubUsername(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		message  string
+		username string
+		matches  bool
+	}{
+		{name: "exact match", message: "deployed by octocat", username: "octocat", matches: true},
+		{name: "case insensitive", message: "OCTOCAT shipped", username: "octocat", matches: true},
+		{name: "substring should fail", message: "octocategories only", username: "octocat", matches: false},
+		{name: "surrounded by punctuation", message: "(octocat)", username: "octocat", matches: true},
+		{name: "missing username", message: "deployed", username: "octocat", matches: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := containsGitHubUsername(tt.message, tt.username)
+			require.Equal(t, tt.matches, got, "containsGitHubUsername(%q, %q)", tt.message, tt.username)
+		})
+	}
+}
+
+func TestPrependSlackMention(t *testing.T) {
+	t.Parallel()
+
+	endpoint := "https://getslackuserid.local/"
+
+	successClient := newTestClient(func(req *http.Request) (*http.Response, error) {
+		if req.URL.String() != endpoint+"octocat" {
+			t.Fatalf("unexpected URL: %s", req.URL.String())
+		}
+		body := io.NopCloser(strings.NewReader(`{"slack_user_id":"U12345"}`))
+		return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+	})
+
+	notFoundClient := newTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("missing"))}, nil
+	})
+
+	errorClient := newTestClient(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("boom")
+	})
+
+	tests := []struct {
+		name       string
+		cfg        config
+		httpClient *http.Client
+		expected   string
+	}{
+		{
+			name: "mentions disabled",
+			cfg: config{
+				Message:         "hello from octocat",
+				GitHubUser:      "octocat",
+				EnableMentions:  false,
+				MappingEndpoint: endpoint,
+			},
+			expected: "hello from octocat",
+		},
+		{
+			name: "empty github user",
+			cfg: config{
+				Message:         "hello",
+				EnableMentions:  true,
+				MappingEndpoint: endpoint,
+			},
+			expected: "hello",
+		},
+		{
+			name: "github user missing in message",
+			cfg: config{
+				Message:         "hello hubot",
+				GitHubUser:      "octocat",
+				EnableMentions:  true,
+				MappingEndpoint: endpoint,
+			},
+			expected: "hello hubot",
+		},
+		{
+			name: "successful mention prepend",
+			cfg: config{
+				Message:         "hello from octocat",
+				GitHubUser:      "octocat",
+				EnableMentions:  true,
+				MappingEndpoint: endpoint,
+			},
+			httpClient: successClient,
+			expected:   "<@U12345>: hello from octocat",
+		},
+		{
+			name: "mapping not found",
+			cfg: config{
+				Message:         "hello from octocat",
+				GitHubUser:      "octocat",
+				EnableMentions:  true,
+				MappingEndpoint: endpoint,
+			},
+			httpClient: notFoundClient,
+			expected:   "hello from octocat",
+		},
+		{
+			name: "mapping request error",
+			cfg: config{
+				Message:         "hello from octocat",
+				GitHubUser:      "octocat",
+				EnableMentions:  true,
+				MappingEndpoint: endpoint,
+			},
+			httpClient: errorClient,
+			expected:   "hello from octocat",
+		},
+		{
+			name: "mapping endpoint missing",
+			cfg: config{
+				Message:        "hello from octocat",
+				GitHubUser:     "octocat",
+				EnableMentions: true,
+			},
+			httpClient: successClient,
+			expected:   "hello from octocat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := prependSlackMention(context.Background(), tt.cfg, tt.httpClient)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestFetchSlackUserID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		client      *http.Client
+		expectedID  string
+		expectError bool
+		errCheck    func(*testing.T, error)
+	}{
+		{
+			name: "success",
+			client: newTestClient(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"slack_user_id":"U4242"}`)),
+				}, nil
+			}),
+			expectedID: "U4242",
+		},
+		{
+			name: "not found",
+			client: newTestClient(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader("missing")),
+				}, nil
+			}),
+			expectError: true,
+			errCheck: func(t *testing.T, err error) {
+				var target *slackUserNotFoundError
+				require.ErrorAs(t, err, &target)
+			},
+		},
+		{
+			name: "unexpected status",
+			client: newTestClient(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader("boom")),
+				}, nil
+			}),
+			expectError: true,
+		},
+		{
+			name: "decode error",
+			client: newTestClient(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("not json")),
+				}, nil
+			}),
+			expectError: true,
+		},
+		{
+			name: "request failure",
+			client: newTestClient(func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("network down")
+			}),
+			expectError: true,
+		},
+	}
+
+	endpoint := "https://getslackuserid.local/"
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := fetchSlackUserID(context.Background(), tt.client, "octocat", endpoint)
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errCheck != nil {
+					tt.errCheck(t, err)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedID, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds opt-in GitHub user -> Slack ID mention capability. Also upgrades to Go 1.25, adds unit tests to cover new logic and a new GitHub Actions workflow that runs Go tests.