### PR TITLE
Notify or invite Slack users mentioned in a channel they're not in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+/docker-slack-message
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 Very simple tool to send Slack messages. Built into a docker image
 
+## Mentioning users who aren't in the channel
+
+When the message tags a Slack user (`<@U...>`) who is not a member of the target
+channel, the mention is otherwise silent. Set `SLACK_MENTION_MEMBERSHIP_MODE` to
+act on every user tagged in the message:
+
+- `none` (default) — do nothing, current behavior.
+- `invite` — invite the tagged users to the channel. Requires the
+  `channels:write.invites` (public) or `groups:write` (private) scope, and the
+  bot must already be a member of the channel (otherwise the invite fails with
+  `not_in_channel`).
+- `notify` — DM each tagged user a link to the channel. Requires `im:write` and
+  `chat:write`. The DM is always sent; membership is not checked first.
+
+Failures here are logged but never fail the run — posting the message is the
+primary success.
+
 ## Testing commands
 
 Requires a bot token (`xoxb-...`). See Slack docs to create one: <https://api.slack.com/quickstart>.

--- a/main.go
+++ b/main.go
@@ -34,12 +34,50 @@ type config struct {
 	GitHubUser        string `envconfig:"GH_USER"`
 	EnableMentions    bool   `envconfig:"ENABLE_SLACK_MENTIONS"`
 	MappingEndpoint   string `envconfig:"GITHUB_SLACK_MAPPING_ENDPOINT"`
+
+	// MentionMembershipMode controls what happens to Slack users tagged in the
+	// message: "none" (default, no-op), "invite" (add them to the channel) or
+	// "notify" (DM them a link to the channel).
+	MentionMembershipMode string `envconfig:"SLACK_MENTION_MEMBERSHIP_MODE" default:"none"`
 }
 
 const (
 	slackMentionTimeout   = 30 * time.Second
 	usernameBoundaryClass = `[^A-Za-z0-9_-]`
 )
+
+type membershipMode string
+
+const (
+	membershipModeNone   membershipMode = "none"
+	membershipModeInvite membershipMode = "invite"
+	membershipModeNotify membershipMode = "notify"
+)
+
+func parseMembershipMode(s string) (membershipMode, error) {
+	switch membershipMode(s) {
+	case "", membershipModeNone:
+		return membershipModeNone, nil
+	case membershipModeInvite, membershipModeNotify:
+		return membershipMode(s), nil
+	default:
+		return "", fmt.Errorf("invalid SLACK_MENTION_MEMBERSHIP_MODE %q (valid: none, invite, notify)", s)
+	}
+}
+
+// slackMembershipClient is the subset of *slack.Client used to invite or notify
+// mentioned users. Defining it as an interface keeps the API calls thin and lets
+// tests inject a fake. *slack.Client satisfies it.
+type slackMembershipClient interface {
+	InviteUsersToConversationContext(ctx context.Context, channelID string, users ...string) (*slack.Channel, error)
+	OpenConversationContext(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)
+	PostMessageContext(ctx context.Context, channelID string, options ...slack.MsgOption) (string, string, error)
+}
+
+// slackMentionRe matches Slack user mentions: <@U012ABC> or <@W012ABC> (W = grid
+// users), optionally with a label as in <@U012ABC|alice>. It deliberately does
+// not match channel mentions (<#C...>) or special mentions (<!here>).
+var slackMentionRe = regexp.MustCompile(`<@([UW][A-Z0-9]+)(?:\|[^>]*)?>`)
 
 type slackUserNotFoundError struct {
 	GitHubUser string
@@ -59,6 +97,12 @@ func main() {
 	var cfg config
 	envconfig.MustProcess("", &cfg)
 	slog.Info("Config loaded", "config", cfg.String())
+
+	mode, err := parseMembershipMode(cfg.MentionMembershipMode)
+	if err != nil {
+		slog.Error("Invalid configuration", "error", err)
+		os.Exit(1)
+	}
 
 	slackClient := slack.New(cfg.Token)
 	httpClient := &http.Client{
@@ -87,6 +131,13 @@ func main() {
 	channelID, messageTs, _, err := slackClient.SendMessage(cfg.Channel, options...)
 	if err != nil {
 		panic(err)
+	}
+
+	// Best-effort: invite or notify any users tagged in the message who may not
+	// be in the channel. Only for new messages/replies — for update the original
+	// send already handled it, and a delete has nothing to be mentioned in.
+	if cfg.UpdateTs == "" && cfg.DeleteTs == "" {
+		ensureMentionMembership(context.Background(), slackClient, mode, channelID, cfg.Message)
 	}
 
 	// threadTs is the timestamp of the root message of a thread.
@@ -187,6 +238,79 @@ func prependSlackMention(ctx context.Context, cfg config, httpClient *http.Clien
 
 	slog.Info("Slack ID found", "github_user", ghUser, "slack_user_id", slackID)
 	return fmt.Sprintf("<@%s>: %s", slackID, message)
+}
+
+// extractMentionedUserIDs returns the unique Slack user IDs mentioned in the
+// message, preserving first-seen order.
+func extractMentionedUserIDs(message string) []string {
+	matches := slackMentionRe.FindAllStringSubmatch(message, -1)
+	seen := make(map[string]struct{}, len(matches))
+	var ids []string
+	for _, m := range matches {
+		if _, ok := seen[m[1]]; ok {
+			continue
+		}
+		seen[m[1]] = struct{}{}
+		ids = append(ids, m[1])
+	}
+	return ids
+}
+
+// ensureMentionMembership invites or notifies (per mode) the users tagged in the
+// message. It is best-effort: every failure is logged, none is fatal.
+func ensureMentionMembership(ctx context.Context, client slackMembershipClient, mode membershipMode, channelID, message string) {
+	if mode == membershipModeNone {
+		return
+	}
+
+	ids := extractMentionedUserIDs(message)
+	if len(ids) == 0 {
+		slog.Info("No Slack mentions found, skipping membership step")
+		return
+	}
+
+	switch mode {
+	case membershipModeInvite:
+		inviteMentionedUsers(ctx, client, channelID, ids)
+	case membershipModeNotify:
+		notifyMentionedUsers(ctx, client, channelID, ids)
+	}
+}
+
+// inviteMentionedUsers invites each user individually. conversations.invite is
+// all-or-nothing per call, so a single already-member id would otherwise block
+// inviting everyone else.
+func inviteMentionedUsers(ctx context.Context, client slackMembershipClient, channelID string, ids []string) {
+	for _, id := range ids {
+		_, err := client.InviteUsersToConversationContext(ctx, channelID, id)
+		if err == nil {
+			slog.Info("Invited user to channel", "channel_id", channelID, "user", id)
+			continue
+		}
+
+		switch err.Error() {
+		case "already_in_channel", "cant_invite_self", "user_is_bot":
+			slog.Info("Invite no-op", "reason", err.Error(), "user", id)
+		default:
+			slog.Warn("Failed to invite user to channel", "channel_id", channelID, "user", id, "error", err)
+		}
+	}
+}
+
+// notifyMentionedUsers DMs each mentioned user a link to the channel.
+func notifyMentionedUsers(ctx context.Context, client slackMembershipClient, channelID string, ids []string) {
+	for _, id := range ids {
+		ch, _, _, err := client.OpenConversationContext(ctx, &slack.OpenConversationParameters{Users: []string{id}})
+		if err != nil {
+			slog.Warn("Failed to open DM", "user", id, "error", err)
+			continue
+		}
+
+		text := fmt.Sprintf("You were mentioned in <#%s>.", channelID)
+		if _, _, err := client.PostMessageContext(ctx, ch.ID, slack.MsgOptionText(text, false)); err != nil {
+			slog.Warn("Failed to send DM", "user", id, "error", err)
+		}
+	}
 }
 
 func containsGitHubUsername(message, username string) bool {

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,6 +20,42 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func newTestClient(fn roundTripFunc) *http.Client {
 	return &http.Client{Transport: fn}
+}
+
+// fakeSlackClient implements slackMembershipClient, recording calls and returning
+// configurable values/errors.
+type fakeSlackClient struct {
+	inviteErr  error
+	invited    []string // user IDs passed to invite (one per call)
+	openErr    error
+	openChanID string
+	postErr    error
+	posted     []string // DM channel IDs posted to
+}
+
+func (f *fakeSlackClient) InviteUsersToConversationContext(_ context.Context, _ string, users ...string) (*slack.Channel, error) {
+	f.invited = append(f.invited, users...)
+	if f.inviteErr != nil {
+		return nil, f.inviteErr
+	}
+	return &slack.Channel{}, nil
+}
+
+func (f *fakeSlackClient) OpenConversationContext(_ context.Context, _ *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+	if f.openErr != nil {
+		return nil, false, false, f.openErr
+	}
+	ch := &slack.Channel{}
+	ch.ID = f.openChanID
+	return ch, false, false, nil
+}
+
+func (f *fakeSlackClient) PostMessageContext(_ context.Context, channelID string, _ ...slack.MsgOption) (string, string, error) {
+	if f.postErr != nil {
+		return "", "", f.postErr
+	}
+	f.posted = append(f.posted, channelID)
+	return channelID, "123.456", nil
 }
 
 func TestContainsGitHubUsername(t *testing.T) {
@@ -237,6 +274,133 @@ func TestFetchSlackUserID(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedID, got)
+		})
+	}
+}
+
+func TestExtractMentionedUserIDs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		message  string
+		expected []string
+	}{
+		{name: "single user", message: "hi <@U123>", expected: []string{"U123"}},
+		{name: "grid user", message: "hi <@W123>", expected: []string{"W123"}},
+		{name: "labeled mention", message: "hi <@U123|alice>", expected: []string{"U123"}},
+		{name: "multiple and dedup", message: "<@U123> and <@U456> and <@U123> again", expected: []string{"U123", "U456"}},
+		{name: "prepended plus raw", message: "<@U999>: ping <@U123>", expected: []string{"U999", "U123"}},
+		{name: "no mentions", message: "nothing here", expected: nil},
+		{name: "ignores channel mention", message: "see <#C123>", expected: nil},
+		{name: "ignores special mention", message: "hey <!here>", expected: nil},
+		{name: "ignores malformed", message: "broken <@123>", expected: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, extractMentionedUserIDs(tt.message))
+		})
+	}
+}
+
+func TestParseMembershipMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		expected  membershipMode
+		expectErr bool
+	}{
+		{name: "empty defaults to none", input: "", expected: membershipModeNone},
+		{name: "none", input: "none", expected: membershipModeNone},
+		{name: "invite", input: "invite", expected: membershipModeInvite},
+		{name: "notify", input: "notify", expected: membershipModeNotify},
+		{name: "unknown errors", input: "bogus", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseMembershipMode(tt.input)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestEnsureMentionMembership(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		mode        membershipMode
+		message     string
+		client      *fakeSlackClient
+		wantInvited []string
+		wantPosted  []string
+	}{
+		{
+			name:    "mode none does nothing",
+			mode:    membershipModeNone,
+			message: "ping <@U123>",
+			client:  &fakeSlackClient{},
+		},
+		{
+			name:    "no mentions does nothing",
+			mode:    membershipModeInvite,
+			message: "nobody here",
+			client:  &fakeSlackClient{},
+		},
+		{
+			name:        "invite invites each user",
+			mode:        membershipModeInvite,
+			message:     "<@U123> and <@U456>",
+			client:      &fakeSlackClient{},
+			wantInvited: []string{"U123", "U456"},
+		},
+		{
+			name:        "invite already_in_channel is non-fatal",
+			mode:        membershipModeInvite,
+			message:     "<@U123>",
+			client:      &fakeSlackClient{inviteErr: errors.New("already_in_channel")},
+			wantInvited: []string{"U123"},
+		},
+		{
+			name:        "invite other error is non-fatal",
+			mode:        membershipModeInvite,
+			message:     "<@U123>",
+			client:      &fakeSlackClient{inviteErr: errors.New("not_in_channel")},
+			wantInvited: []string{"U123"},
+		},
+		{
+			name:       "notify DMs each user",
+			mode:       membershipModeNotify,
+			message:    "<@U123> and <@U456>",
+			client:     &fakeSlackClient{openChanID: "D999"},
+			wantPosted: []string{"D999", "D999"},
+		},
+		{
+			name:       "notify open error skips that user",
+			mode:       membershipModeNotify,
+			message:    "<@U123>",
+			client:     &fakeSlackClient{openErr: errors.New("user_not_found")},
+			wantPosted: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ensureMentionMembership(context.Background(), tt.client, tt.mode, "C123", tt.message)
+			require.Equal(t, tt.wantInvited, tt.client.invited)
+			require.Equal(t, tt.wantPosted, tt.client.posted)
 		})
 	}
 }

--- a/test.sh
+++ b/test.sh
@@ -30,3 +30,7 @@ ${RUN} -e SLACK_CHANNEL=$(cat ${WORKDIR}/channel-id) -e SLACK_MESSAGE=reply1-upd
 
 # Delete second message
 ${RUN} -e SLACK_CHANNEL=$(cat ${WORKDIR}/channel-id) -e SLACK_DELETE_MESSAGE_TS=${SECOND_MESSAGE_TS} ${IMAGE}
+
+# Tag a user and invite them to the channel if they aren't a member.
+# Replace U0000000000 with a real user ID; use SLACK_MENTION_MEMBERSHIP_MODE=notify to DM instead.
+# ${RUN} -e SLACK_CHANNEL -e SLACK_MESSAGE='heads up <@U0000000000>' -e SLACK_MENTION_MEMBERSHIP_MODE=invite ${IMAGE}


### PR DESCRIPTION
A tagged Slack handle is silent when the user isn't a member of the channel: they get no notification and can't see the message, so the mention is effectively lost. Add SLACK_MENTION_MEMBERSHIP_MODE so an automation can opt into inviting those users to the channel or DMing them a link, keeping mentions actionable. Defaults to none to preserve existing behavior; the step is best-effort and never fails the run.