### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+
+permissions:
+  contents: read
+
 jobs:
   go-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Small CI hardening: declares an explicit workflow-level `permissions: contents: read` on 1 workflow(s) that currently inherit the default broad read-write GITHUB_TOKEN.

I inspected each file before including it; none publish, push, comment on issues/PRs, or otherwise write via the GitHub API, so the read-only default does not change behavior. Workflows that need to write (stale, release, gh-pages-deploy, publish actions, etc.) are intentionally left out of this PR.

This is the post-CVE-2025-30066 hardening pattern for default token scope.