### PR TITLE
feat: add persistent HTTP server mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,7 @@ FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a
 COPY --from=build /app/slack-message /app/slack-message
 RUN mkdir /app/outputs
 
+# Default server-mode port (only used when SLACK_SERVER_MODE=true).
+EXPOSE 8080
+
 ENTRYPOINT ["/app/slack-message"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,41 @@
 
 Very simple tool to send Slack messages. Built into a docker image
 
+## Server mode
+
+By default the container sends a single message (configured via environment
+variables) and exits. Set `SLACK_SERVER_MODE=true` to instead run a persistent
+HTTP server that posts a Slack message for each incoming `POST` request.
+
+- The bot token is **only** read from the `SLACK_TOKEN` environment variable. It
+  is never accepted in the request body (sending a `token` field returns
+  `400`).
+- `GITHUB_SLACK_MAPPING_ENDPOINT` is also read from the environment (shared
+  across requests).
+- `SLACK_SERVER_ADDR` sets the listen address (default `:8080`).
+- `GET /healthz` returns `200` for health checks.
+
+Every other field is supplied per request as JSON. `channel` is required:
+
+```bash
+docker run -p 8080:8080 -e SLACK_SERVER_MODE=true -e SLACK_TOKEN="xoxb-..." docker-slack-message
+
+curl -sS -X POST http://localhost:8080/ \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "channel": "C0123456789",
+        "title": "Deploy finished",
+        "message": "All good :rocket:",
+        "color": "#008000"
+      }'
+# => {"channel_id":"C0123456789","message_ts":"...","thread_ts":"..."}
+```
+
+Supported body fields: `channel`, `title`, `message`, `context`, `color`,
+`thread_ts`, `update_message_ts`, `delete_message_ts`, `also_send_to_channel`,
+`gh_user`, `enable_mentions`, `mention_membership_mode`. The response is JSON
+with `channel_id`, `message_ts` and `thread_ts`.
+
 ## Mentioning users who aren't in the channel
 
 When the message tags a Slack user (`<@U...>`) who is not a member of the target

--- a/main.go
+++ b/main.go
@@ -9,8 +9,10 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"regexp"
+	"syscall"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -18,33 +20,62 @@ import (
 )
 
 type config struct {
-	// Content
-	Color   string `envconfig:"SLACK_COLOR" default:"#008000"`
-	Title   string `envconfig:"SLACK_TITLE"`
-	Message string `envconfig:"SLACK_MESSAGE"`
-	Context string `envconfig:"SLACK_CONTEXT"`
+	// Server settings. These are never read from the request body: the bot
+	// token in particular must only ever come from the environment.
+	ServerMode bool   `envconfig:"SLACK_SERVER_MODE" default:"false" json:"-"`
+	ServerAddr string `envconfig:"SLACK_SERVER_ADDR" default:":8080" json:"-"`
+	Token      string `envconfig:"SLACK_TOKEN" required:"true" json:"-"`
+	OutputDir  string `envconfig:"SLACK_OUTPUT_DIR" default:"/app/outputs" json:"-"`
+	// MappingEndpoint is infrastructure-level config shared across messages, so
+	// it is read from the environment in both modes rather than per request.
+	MappingEndpoint string `envconfig:"GITHUB_SLACK_MAPPING_ENDPOINT" json:"-"`
 
-	AlsoSendToChannel bool   `envconfig:"SLACK_ALSO_SEND_TO_CHANNEL" default:"false"`
-	Channel           string `envconfig:"SLACK_CHANNEL" required:"true"`
-	OutputDir         string `envconfig:"SLACK_OUTPUT_DIR" default:"/app/outputs"`
-	ThreadTs          string `envconfig:"SLACK_THREAD_TS"`
-	UpdateTs          string `envconfig:"SLACK_UPDATE_MESSAGE_TS"`
-	DeleteTs          string `envconfig:"SLACK_DELETE_MESSAGE_TS"`
-	Token             string `envconfig:"SLACK_TOKEN" required:"true"`
-	GitHubUser        string `envconfig:"GH_USER"`
-	EnableMentions    bool   `envconfig:"ENABLE_SLACK_MENTIONS"`
-	MappingEndpoint   string `envconfig:"GITHUB_SLACK_MAPPING_ENDPOINT"`
+	// Content. In CLI mode these come from environment variables; in server mode
+	// they come from the JSON request body.
+	Color   string `envconfig:"SLACK_COLOR" default:"#008000" json:"color"`
+	Title   string `envconfig:"SLACK_TITLE" json:"title"`
+	Message string `envconfig:"SLACK_MESSAGE" json:"message"`
+	Context string `envconfig:"SLACK_CONTEXT" json:"context"`
+
+	AlsoSendToChannel bool   `envconfig:"SLACK_ALSO_SEND_TO_CHANNEL" default:"false" json:"also_send_to_channel"`
+	Channel           string `envconfig:"SLACK_CHANNEL" json:"channel"`
+	ThreadTs          string `envconfig:"SLACK_THREAD_TS" json:"thread_ts"`
+	UpdateTs          string `envconfig:"SLACK_UPDATE_MESSAGE_TS" json:"update_message_ts"`
+	DeleteTs          string `envconfig:"SLACK_DELETE_MESSAGE_TS" json:"delete_message_ts"`
+	GitHubUser        string `envconfig:"GH_USER" json:"gh_user"`
+	EnableMentions    bool   `envconfig:"ENABLE_SLACK_MENTIONS" json:"enable_mentions"`
 
 	// MentionMembershipMode controls what happens to Slack users tagged in the
 	// message: "none" (default, no-op), "invite" (add them to the channel) or
 	// "notify" (DM them a link to the channel).
-	MentionMembershipMode string `envconfig:"SLACK_MENTION_MEMBERSHIP_MODE" default:"none"`
+	MentionMembershipMode string `envconfig:"SLACK_MENTION_MEMBERSHIP_MODE" default:"none" json:"mention_membership_mode"`
 }
 
 const (
-	slackMentionTimeout   = 30 * time.Second
-	usernameBoundaryClass = `[^A-Za-z0-9_-]`
+	slackMentionTimeout     = 30 * time.Second
+	usernameBoundaryClass   = `[^A-Za-z0-9_-]`
+	serverShutdownTimeout   = 10 * time.Second
+	serverReadHeaderTimeout = 10 * time.Second
+	maxRequestBodyBytes     = 1 << 20 // 1 MiB
 )
+
+// validationError marks a request-level problem (bad input) as opposed to an
+// internal/Slack failure, so the HTTP server can answer 400 instead of 500.
+type validationError struct{ err error }
+
+func (e *validationError) Error() string { return e.err.Error() }
+
+func newValidationError(format string, args ...any) error {
+	return &validationError{err: fmt.Errorf(format, args...)}
+}
+
+// sendResult is the outcome of posting a message, returned to server clients as
+// JSON and written to the output directory in CLI mode.
+type sendResult struct {
+	ChannelID string `json:"channel_id"`
+	MessageTs string `json:"message_ts"`
+	ThreadTs  string `json:"thread_ts"`
+}
 
 type membershipMode string
 
@@ -88,9 +119,16 @@ func (e *slackUserNotFoundError) Error() string {
 }
 
 func (c config) String() string {
-	c.Token = c.Token[:8] + "..."
+	c.Token = redactToken(c.Token)
 	json, _ := json.MarshalIndent(c, "", "  ")
 	return string(json)
+}
+
+func redactToken(token string) string {
+	if len(token) <= 8 {
+		return "..."
+	}
+	return token[:8] + "..."
 }
 
 func main() {
@@ -98,25 +136,65 @@ func main() {
 	envconfig.MustProcess("", &cfg)
 	slog.Info("Config loaded", "config", cfg.String())
 
-	mode, err := parseMembershipMode(cfg.MentionMembershipMode)
-	if err != nil {
-		slog.Error("Invalid configuration", "error", err)
-		os.Exit(1)
-	}
-
 	slackClient := slack.New(cfg.Token)
 	httpClient := &http.Client{
 		Timeout: slackMentionTimeout,
 	}
 
-	cfg.Message = prependSlackMention(context.Background(), cfg, httpClient)
+	if cfg.ServerMode {
+		if err := runServer(cfg, slackClient, httpClient); err != nil {
+			slog.Error("Server stopped with error", "error", err)
+			os.Exit(1)
+		}
+		return
+	}
 
-	if cfg.UpdateTs != "" && cfg.DeleteTs != "" {
-		slog.Error("Cannot update and delete a message at the same time")
+	if cfg.Channel == "" {
+		slog.Error("Invalid configuration", "error", "SLACK_CHANNEL is required")
 		os.Exit(1)
 	}
 
-	// Send the message
+	result, err := sendSlackMessage(context.Background(), cfg, slackClient, httpClient)
+	if err != nil {
+		slog.Error("Failed to send message", "error", err)
+		os.Exit(1)
+	}
+
+	// Write the channelID, messageTs and threadTs to a file to be reused in another container (For example, steps in Argo Workflows)
+	// ThreadTs: timestamp of the root message of a thread
+	// MessageTs: timestamp of the message (root or reply)
+	// ChannelID: ID of the channel where the message was sent. This is required to update messages. The API requires the ID, not the name.
+	if cfg.OutputDir != "" {
+		slog.Info("channel-id written", "channel_id", result.ChannelID)
+		if err := os.WriteFile(filepath.Join(cfg.OutputDir, "channel-id"), []byte(result.ChannelID), 0644); err != nil {
+			panic(err)
+		}
+		slog.Info("message-ts written", "message_ts", result.MessageTs)
+		if err := os.WriteFile(filepath.Join(cfg.OutputDir, "message-ts"), []byte(result.MessageTs), 0644); err != nil {
+			panic(err)
+		}
+		slog.Info("thread-ts written", "thread_ts", result.ThreadTs)
+		if err := os.WriteFile(filepath.Join(cfg.OutputDir, "thread-ts"), []byte(result.ThreadTs), 0644); err != nil {
+			panic(err)
+		}
+	}
+}
+
+// sendSlackMessage posts (or updates/deletes) a message according to cfg and
+// returns the resulting identifiers. It is the shared core used by both the CLI
+// and the HTTP server.
+func sendSlackMessage(ctx context.Context, cfg config, slackClient *slack.Client, httpClient *http.Client) (sendResult, error) {
+	mode, err := parseMembershipMode(cfg.MentionMembershipMode)
+	if err != nil {
+		return sendResult{}, &validationError{err: err}
+	}
+
+	if cfg.UpdateTs != "" && cfg.DeleteTs != "" {
+		return sendResult{}, newValidationError("cannot update and delete a message at the same time")
+	}
+
+	cfg.Message = prependSlackMention(ctx, cfg, httpClient)
+
 	options := []slack.MsgOption{content(cfg)}
 	if cfg.UpdateTs != "" {
 		options = append(options, slack.MsgOptionUpdate(cfg.UpdateTs))
@@ -128,16 +206,17 @@ func main() {
 			options = append(options, slack.MsgOptionBroadcast())
 		}
 	}
-	channelID, messageTs, _, err := slackClient.SendMessage(cfg.Channel, options...)
+
+	channelID, messageTs, _, err := slackClient.SendMessageContext(ctx, cfg.Channel, options...)
 	if err != nil {
-		panic(err)
+		return sendResult{}, fmt.Errorf("send message: %w", err)
 	}
 
 	// Best-effort: invite or notify any users tagged in the message who may not
 	// be in the channel. Only for new messages/replies — for update the original
 	// send already handled it, and a delete has nothing to be mentioned in.
 	if cfg.UpdateTs == "" && cfg.DeleteTs == "" {
-		ensureMentionMembership(context.Background(), slackClient, mode, channelID, cfg.Message)
+		ensureMentionMembership(ctx, slackClient, mode, channelID, cfg.Message)
 	}
 
 	// threadTs is the timestamp of the root message of a thread.
@@ -149,22 +228,95 @@ func main() {
 		threadTs = messageTs
 	}
 
-	// Write the channelID, messageTs and threadTs to a file to be reused in another container (For example, steps in Argo Workflows)
-	// ThreadTs: timestamp of the root message of a thread
-	// MessageTs: timestamp of the message (root or reply)
-	// ChannelID: ID of the channel where the message was sent. This is required to update messages. The API requires the ID, not the name.
-	if cfg.OutputDir != "" {
-		slog.Info("channel-id written", "channel_id", channelID)
-		if err := os.WriteFile(filepath.Join(cfg.OutputDir, "channel-id"), []byte(channelID), 0644); err != nil {
-			panic(err)
+	return sendResult{ChannelID: channelID, MessageTs: messageTs, ThreadTs: threadTs}, nil
+}
+
+// runServer starts a persistent HTTP server that posts a Slack message for each
+// POST request. The bot token and other infrastructure settings come from the
+// environment (serverCfg); the per-message fields come from the request body.
+func runServer(serverCfg config, slackClient *slack.Client, httpClient *http.Client) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/", slackMessageHandler(serverCfg, slackClient, httpClient))
+
+	server := &http.Server{
+		Addr:              serverCfg.ServerAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: serverReadHeaderTimeout,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	errCh := make(chan error, 1)
+	go func() {
+		slog.Info("Slack message server listening", "addr", serverCfg.ServerAddr)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
 		}
-		slog.Info("message-ts written", "message_ts", messageTs)
-		if err := os.WriteFile(filepath.Join(cfg.OutputDir, "message-ts"), []byte(messageTs), 0644); err != nil {
-			panic(err)
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		slog.Info("Shutdown signal received, stopping server")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
+		defer cancel()
+		return server.Shutdown(shutdownCtx)
+	}
+}
+
+// slackMessageHandler builds an HTTP handler that decodes a per-message config
+// from the request body, injects the environment-only settings (token, mapping
+// endpoint), and posts the message.
+func slackMessageHandler(serverCfg config, slackClient *slack.Client, httpClient *http.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
 		}
-		slog.Info("thread-ts written", "thread_ts", threadTs)
-		if err := os.WriteFile(filepath.Join(cfg.OutputDir, "thread-ts"), []byte(threadTs), 0644); err != nil {
-			panic(err)
+
+		// Defaults that envconfig would otherwise apply for CLI mode.
+		reqCfg := config{
+			Color:                 "#008000",
+			MentionMembershipMode: string(membershipModeNone),
+		}
+		dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxRequestBodyBytes))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&reqCfg); err != nil {
+			http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		// The token and mapping endpoint always come from the environment, never
+		// the request body (json:"-" prevents the body from overriding them).
+		reqCfg.Token = serverCfg.Token
+		reqCfg.MappingEndpoint = serverCfg.MappingEndpoint
+
+		if reqCfg.Channel == "" {
+			http.Error(w, "channel is required", http.StatusBadRequest)
+			return
+		}
+
+		slog.Info("Handling message request", "channel", reqCfg.Channel)
+		result, err := sendSlackMessage(r.Context(), reqCfg, slackClient, httpClient)
+		if err != nil {
+			var validErr *validationError
+			if errors.As(err, &validErr) {
+				http.Error(w, validErr.Error(), http.StatusBadRequest)
+				return
+			}
+			slog.Error("Failed to send message", "error", err)
+			http.Error(w, "failed to send message", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(result); err != nil {
+			slog.Error("Failed to encode response", "error", err)
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -331,6 +332,40 @@ func TestParseMembershipMode(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestSlackMessageHandlerValidation covers the request paths that fail before
+// any Slack API call, so a nil client is never reached.
+func TestSlackMessageHandlerValidation(t *testing.T) {
+	t.Parallel()
+
+	serverCfg := config{Token: "xoxb-secret-token", MappingEndpoint: "https://map.local/"}
+	handler := slackMessageHandler(serverCfg, nil, nil)
+
+	tests := []struct {
+		name       string
+		method     string
+		body       string
+		wantStatus int
+	}{
+		{name: "method not allowed", method: http.MethodGet, body: "", wantStatus: http.StatusMethodNotAllowed},
+		{name: "invalid json", method: http.MethodPost, body: "not json", wantStatus: http.StatusBadRequest},
+		{name: "missing channel", method: http.MethodPost, body: `{"message":"hi"}`, wantStatus: http.StatusBadRequest},
+		{name: "token in body rejected", method: http.MethodPost, body: `{"channel":"C1","token":"xoxb-evil"}`, wantStatus: http.StatusBadRequest},
+		{name: "unknown field rejected", method: http.MethodPost, body: `{"channel":"C1","bogus":true}`, wantStatus: http.StatusBadRequest},
+		{name: "invalid membership mode", method: http.MethodPost, body: `{"channel":"C1","mention_membership_mode":"bogus"}`, wantStatus: http.StatusBadRequest},
+		{name: "update and delete conflict", method: http.MethodPost, body: `{"channel":"C1","update_message_ts":"1","delete_message_ts":"2"}`, wantStatus: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(tt.method, "/", strings.NewReader(tt.body))
+			rec := httptest.NewRecorder()
+			handler(rec, req)
+			require.Equal(t, tt.wantStatus, rec.Code)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Add a persistent HTTP server mode so the container can stay up and post a Slack message for each incoming request, instead of running once per invocation. The single-shot CLI behavior is unchanged and remains the default.

- Set `SLACK_SERVER_MODE=true` to start an HTTP server (`SLACK_SERVER_ADDR`, default `:8080`); `POST /` posts a message from a JSON body and returns `{channel_id, message_ts, thread_ts}`, and `GET /healthz` returns `200`.
- The bot token is read only from `SLACK_TOKEN`. The request body cannot set it: token (and other infra fields) are `json:"-"` and `DisallowUnknownFields` rejects a `token` field with `400`.
- The send/update/delete logic is now shared between CLI and server via `sendSlackMessage`; bad input (invalid mode, update+delete conflict, missing channel) returns `400`, internal failures return a generic `500`.
- Hardened the server with a request body size limit and a read-header timeout.


Made with [Cursor](https://cursor.com)